### PR TITLE
Fix `ResultWidget::new` when `entry` is unicode

### DIFF
--- a/src/fuzzy/mod.rs
+++ b/src/fuzzy/mod.rs
@@ -1,6 +1,7 @@
 use std::cmp::max;
 
-use self::util::{find_longest_match, slice_utf8};
+use self::util::find_longest_match;
+pub use self::util::slice_utf8;
 
 mod util;
 

--- a/src/launcher/result.rs
+++ b/src/launcher/result.rs
@@ -1,6 +1,6 @@
 use gtk::{prelude::*, Builder, EventBox, Image, Label};
 
-use crate::{entry::ResultEntry, fuzzy::MatchingBlocks, launcher::window::Window};
+use crate::{entry::ResultEntry, fuzzy::{ MatchingBlocks, slice_utf8 }, launcher::window::Window};
 
 #[derive(Debug, Clone)]
 pub struct ResultWidget {
@@ -35,14 +35,16 @@ impl ResultWidget {
     );
     let close_tag = "</span>";
 
-    let mut name_c = entry.name().to_string();
-    for (_, (index, chars)) in match_.0.iter().rev().enumerate() {
-      name_c = name_c[0..*index].to_string().to_string()
-        + &open_tag
-        + &chars
-        + close_tag
-        + &name_c[index + chars.len()..];
-    }
+    let name_c = match_.0
+        .iter()
+        .rev()
+        .fold(entry.name().to_string(), |name_c, (index, chars)| {
+            [slice_utf8(&name_c, 0, *index),
+            &open_tag,
+            &chars,
+            close_tag,
+            slice_utf8(&name_c, *index + chars.chars().count(), name_c.chars().count())].concat()
+    });
 
     item_name.set_markup(&name_c);
 


### PR DESCRIPTION
## Error
```
thread 'main' panicked at 'byte index 18 is not a char boundary; it is inside 'õ' (bytes 17..19) of `Editor de partições GParted`'
```

## Explanation
This happens because of "raw" string indexing in `src/launcher/result.rs:40` (74d8e30):

```rust
    let mut name_c = entry.name().to_string();
    for (_, (index, chars)) in match_.0.iter().rev().enumerate() {
      // Here
      name_c = name_c[0..*index].to_string().to_string()
        + &open_tag
        + &chars
        + close_tag
        // Here too
        + &name_c[index + chars.len()..];
    }
```

Since string in rust are internally UTF-8 encoded, it's fine to index them in
ascii-only environments, however it panics if the index is in a unicode char
boundry.

## Fix
I exported `fuzzy::utils::slice_utf8` since it's already there and it worked great :)

Also, just a suggestion: since you grabbed a some functions from `fuzzywuzzy`, you should consider outright depending on it as rustc is smart enough to remove functions not in use.